### PR TITLE
docs: async jobs, webhooks, and verification scripts

### DIFF
--- a/api-reference/endpoint/async.mdx
+++ b/api-reference/endpoint/async.mdx
@@ -1,0 +1,53 @@
+---
+title: 'Create Async Job'
+description: 'Enqueue a long‑running chat completion job and poll for status'
+---
+
+The async API lets you submit chat completion requests that are processed in the background, instead of blocking on a single HTTP call.
+
+At a high level you:
+
+1. **Enqueue** a job with `POST /v1/chat/completions/async`.
+2. **Poll** job status with `GET /v1/requests/{requestId}/status`.
+
+### Enqueue an async job
+
+```bash
+curl -sS https://api.subconscious.dev/v1/chat/completions/async \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "tim-large",
+    "messages": [
+      { "role": "user", "content": "Run this as an async job" }
+    ]
+  }'
+```
+
+The response contains:
+
+- `requestId` – the stable identifier you use when polling.
+- `status` – typically `"pending"` immediately after enqueue.
+- `estimatedCompletionTime` – rough estimate to help with UX.
+
+### Poll job status
+
+```bash
+curl -sS https://api.subconscious.dev/v1/requests/REQUEST_ID/status \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  | jq
+```
+
+The status payload includes:
+
+- `status`: `pending | processing | completed | failed | cancelled`
+- `jobId`: internal job identifier
+- `model` / `engine`
+- `result` (when completed)
+- `error` (when failed)
+- timestamps (`createdAt`, `updatedAt`, `startedAt`, `completedAt`)
+
+You can poll until `status` is either `completed` or `failed`. For many workloads a simple loop with a small delay (1–5 seconds) is sufficient.
+
+> For webhook‑based notifications on completion, see the “Async jobs and webhooks” guide in the Platform section.
+

--- a/api-reference/endpoint/webhooks.mdx
+++ b/api-reference/endpoint/webhooks.mdx
@@ -1,0 +1,160 @@
+---
+title: 'Webhooks'
+description: 'Configure and verify webhooks for async jobs'
+---
+
+Webhooks let Subconscious notify your system when async jobs complete or fail. This page covers:
+
+- Managing persistent webhook subscriptions.
+- Using ephemeral `callbackUrl` values on individual async requests.
+- The canary endpoint for end‑to‑end verification.
+
+> All webhook endpoints use Bearer token authentication; you must include your API key in the `Authorization` header.
+
+## Create a webhook subscription
+
+**Endpoint**
+
+```text
+POST /v1/webhooks/subscriptions
+```
+
+**Request body**
+
+```json
+{
+  "callbackUrl": "https://your-app.example.com/webhooks/subconscious",
+  "eventTypes": ["job.succeeded", "job.failed"],
+  "secret": "optional-shared-secret",
+  "description": "My async job webhooks"
+}
+```
+
+- `callbackUrl` (string, required): where we should send events.
+- `eventTypes` (array, required): which events you want to receive. Currently:
+  - `job.succeeded`
+  - `job.failed`
+- `secret` (string, optional): shared secret used to sign webhook payloads.
+- `description` (string, optional): your own label for the subscription.
+
+**Example**
+
+```bash
+curl -sS https://api.subconscious.dev/v1/webhooks/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "callbackUrl": "https://your-app.example.com/webhooks/subconscious",
+    "eventTypes": ["job.succeeded", "job.failed"],
+    "secret": "replace-with-a-strong-secret",
+    "description": "Async job notifications"
+  }'
+```
+
+The response includes the created subscription, including its `id`.
+
+## List webhook subscriptions
+
+**Endpoint**
+
+```text
+GET /v1/webhooks/subscriptions
+```
+
+Returns all subscriptions owned by the authenticated organization:
+
+```json
+{
+  "subscriptions": [
+    {
+      "id": "sub_...",
+      "orgId": "org_...",
+      "callbackUrl": "https://your-app.example.com/webhooks/subconscious",
+      "eventTypes": ["job.succeeded", "job.failed"],
+      "secret": "…",
+      "description": "Async job notifications",
+      "createdAt": "2025-01-01T00:00:00.000Z",
+      "updatedAt": "2025-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+**Example**
+
+```bash
+curl -sS https://api.subconscious.dev/v1/webhooks/subscriptions \
+  -H "Authorization: Bearer YOUR_API_KEY" | jq
+```
+
+## Delete a webhook subscription
+
+**Endpoint**
+
+```text
+DELETE /v1/webhooks/subscriptions/{id}
+```
+
+Deletes a subscription you own. Returns `204 No Content` on success.
+
+**Example**
+
+```bash
+curl -sS -X DELETE \
+  https://api.subconscious.dev/v1/webhooks/subscriptions/sub_123 \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -i
+```
+
+If the subscription does not exist, you’ll get `404`. If it belongs to another org, you’ll get `403`.
+
+## Ephemeral callbackUrl on async requests
+
+In addition to persistent subscriptions, you can attach a one‑off `callbackUrl` to an individual async job:
+
+```bash
+curl -sS https://api.subconscious.dev/v1/chat/completions/async \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "tim-large",
+    "messages": [
+      { "role": "user", "content": "Run this as an async job" }
+    ],
+    "callbackUrl": "https://your-app.example.com/webhooks/subconscious"
+  }'
+```
+
+When the job finishes, we enqueue a webhook delivery for that `callbackUrl` in addition to any matching subscriptions.
+
+## Canary endpoint
+
+The canary endpoint lets you verify your webhook receiver and our delivery pipeline end‑to‑end.
+
+**Endpoint**
+
+```text
+POST /v1/webhooks/canary
+```
+
+**Request body**
+
+```json
+{
+  "callbackUrl": "https://your-app.example.com/webhooks/subconscious"
+}
+```
+
+**Example**
+
+```bash
+curl -sS https://api.subconscious.dev/v1/webhooks/canary \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "callbackUrl": "https://your-app.example.com/webhooks/subconscious"
+  }'
+```
+
+On success we respond with `202 Accepted` and a small body describing the enqueued canary delivery. You should then see a webhook arrive at your `callbackUrl` with a synthetic payload indicating that this is a canary event.
+

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -5,11 +5,18 @@ description: "Welcome to the Subconscious AI API documentation"
 
 ## Welcome
 
-Our API is designed with simplicity in mind. We currently support one primary endpoint that's fully OpenAI-compatible, making it incredibly easy to start experimenting with our TIM inference engines immediately. Simply swap out your OpenAI API key and endpoint, and you're ready to go.
+Our API is designed with simplicity in mind. The core surface is OpenAI-compatible chat completions, making it easy to start experimenting with our TIM inference engines immediately. Simply swap out your OpenAI API key and endpoint, and you're ready to go.
 
 ## Current Offerings
 
 Right now, we focus on doing one thing exceptionally well: **chat completions**. Our `/chat/completions` endpoint is fully compatible with OpenAI's API format, so you can integrate our TIM engines into your existing workflows without any code changes.
+
+On top of the sync (blocking) chat completion API, we also expose an async flow for long‑running or durable work:
+
+- `POST /v1/chat/completions/async` – enqueue a job.
+- `GET /v1/requests/{requestId}/status` – poll job status and results.
+
+The async API uses the same request shape as the sync endpoint; the main difference is that you get back a `requestId` immediately and fetch the result later.
 
 We're adding a lot more functionality in the near future, but we wanted to release something as quickly as possible to get your feedback.
 

--- a/docs.json
+++ b/docs.json
@@ -30,6 +30,7 @@
             "pages": [
               "platform/using-subconscious",
               "platform/models",
+              "platform/async-jobs-and-webhooks",
               "platform/tools",
               "platform/pricing",
               "platform/logs",
@@ -59,7 +60,9 @@
           {
             "group": "Endpoint Examples",
             "pages": [
-              "api-reference/endpoint/post"
+              "api-reference/endpoint/post",
+              "api-reference/endpoint/async",
+              "api-reference/endpoint/webhooks"
             ]
           }
         ]

--- a/platform/async-jobs-and-webhooks.mdx
+++ b/platform/async-jobs-and-webhooks.mdx
@@ -1,0 +1,117 @@
+---
+title: 'Async jobs and webhooks'
+description: 'Run long‑running agent work reliably and get notified on completion'
+---
+import ResearchPreview from '/snippets/research-preview.mdx';
+import AsyncPolling from '/snippets/async-polling.mdx';
+import AsyncWebhook from '/snippets/async-webhook.mdx';
+
+<ResearchPreview />
+
+## Why async?
+
+Streaming responses are great when you want a human in the loop, but some workloads:
+
+- Run for a long time (many tool calls, large searches, multi‑step plans).
+- Must be durable (you care that they finish, not that you watched every token).
+- Need to fan out results to other systems (pipelines, CRMs, warehouses, etc.).
+
+For those cases we expose an async pipeline with:
+
+- **Async jobs** – you submit work, we enqueue and process it in the background.
+- **Polling** – you can check the status and result at any time.
+- **Webhooks** – we can call back into your system when the job finishes.
+
+You get the same agent behavior as the sync API, but with better durability and control.
+
+## High‑level architecture
+
+At a high level, the async path looks like this:
+
+1. You call `POST /v1/chat/completions/async` with your usual model + messages.
+2. We create an async job and enqueue it into an internal SQS queue.
+3. A dedicated worker service pulls jobs from the queue and runs them against the engine.
+4. On completion we:
+   - update the job status, and
+   - optionally enqueue one or more webhook deliveries.
+5. You:
+   - poll the status endpoint, or
+   - receive a webhook at your configured callback URL.
+
+You never talk to the queue or workers directly; you only use the HTTP API.
+
+## Async jobs & polling
+
+The core entrypoint is:
+
+- `POST /v1/chat/completions/async`
+
+You send the same shape you would send to the sync API, but instead of waiting for the model to finish we:
+
+- return quickly with:
+  - a `requestId`,
+  - `status: "pending"`, and
+  - an estimated completion time.
+- do the work in the background.
+
+To check on the job later, you use:
+
+- `GET /v1/requests/{requestId}/status`
+
+The status payload contains:
+
+- `status`: `pending | processing | completed | failed | cancelled`
+- `jobId`: internal job identifier
+- `model` / `engine`
+- `result` (when completed)
+- `error` (when failed)
+- timestamps (`createdAt`, `updatedAt`, `startedAt`, `completedAt`)
+
+This polling contract is the “source of truth” for async job state.
+
+<AsyncPolling />
+
+## Webhooks
+
+Polling is ideal when you have a single client watching a single job. For automation and integrations, it’s more natural for us to notify you when jobs finish.
+
+You have two options:
+
+1. **Ephemeral webhooks** – you pass a `callbackUrl` on the async request, and we call that URL once when the job finishes.
+2. **Persistent subscriptions** – you register webhook subscriptions for events like `job.completed` or `job.failed`, and we fan out to all matching subscribers.
+
+In both cases, webhook deliveries:
+
+- are queued and retried with exponential backoff,
+- use timeouts to avoid hanging on bad receivers,
+- eventually land in a DLQ if they cannot be delivered,
+- are stored in our database so you can inspect their status.
+
+<AsyncWebhook />
+
+## When to use what
+
+Use **sync + streaming** when:
+
+- a human is watching the response,
+- you care more about interactivity than durability.
+
+Use **async + polling** when:
+
+- the job may take a while,
+- you have a client that can easily poll (dashboard, CLI, cron job),
+- you want a simple way to check status and surface errors.
+
+Use **async + webhooks** when:
+
+- you want to plug agents into other systems (HubSpot, Salesforce, workflow engines),
+- you need a reliable, push‑based notification that work finished,
+- you want a clear audit trail of deliveries and retries.
+
+You can mix these patterns: for example, submit async jobs from a backend, poll in a dashboard, and use webhooks to trigger follow‑up automations.
+
+## Related docs
+
+- **Quickstart** – see the async polling example for a minimal curl flow.
+- **API Reference** – `POST /v1/chat/completions/async`, `GET /v1/requests/{requestId}/status`, and the `/v1/webhooks/*` endpoints.
+- **Logs** – how to inspect worker logs, queue age, and delivery errors.

--- a/platform/logs.mdx
+++ b/platform/logs.mdx
@@ -38,3 +38,28 @@ Our comprehensive logging system helps you:
 - **Monitor performance** - Track response times and success rates
 - **Understand agent behavior** - See the complete reasoning process
 - **Audit usage** - Maintain detailed records of all interactions
+
+
+## Async jobs and webhook logs
+
+For async workloads and webhooks there are a few additional places to look:
+
+- **Worker logs**
+  - Async worker: processes jobs from the queue and calls the engine.
+  - Webhook worker: delivers webhook POSTs and handles retries/backoff.
+  - Logs include:
+    - `requestId`, `jobId`, `deliveryId`, `orgId`,
+    - `durationMs`, `queueAgeMs`, `status`, `errorCode`.
+
+- **Queue health and scaling**
+  - We emit metrics and alarms around:
+    - Async queue age,
+    - Webhook queue age,
+    - Async and webhook DLQ depth.
+  - This makes it easy to spot stuck backlogs or failing deliveries.
+
+- **Local test logs**
+  - When you run our helper scripts (for example `run-all-tests.sh`), we write:
+    - `*-jest.log`, `*-tsc.log`, `*-env.log`, and queue snapshots
+      under `apps/api/test-logs/` in the monorepo.
+  - These logs help you verify that your environment is wired correctly and make regressions easy to detect.

--- a/platform/models.mdx
+++ b/platform/models.mdx
@@ -21,7 +21,8 @@ TIM-small-preview is our core fine-tuned TIM-8b model running on TIMRUN. It enab
 
 TIM-large is a highly capable generalized inference engine built on the same principles as TIM-small but backed by the power of OpenAI GPT-4.1. We talked to teams around the world building agents, and many won't deviate from using anything but the most powerful generalized models. We listened, and we built a way to experience long horizon reasoning and the agent developer experience we imagined backed by the power of models you're more familiar with.
 
+Both models can be used with either the sync or async APIs. In async mode, we enqueue work for a background worker to process and expose a simple polling + webhook story for long‑running jobs.
+
 ## Terminology
 
 We'll use the phrase model and inference engine interchangeably. We really have models which are transformer models, a runtime, which is, we're usually referring to Tim run, which is our custom runtime that runs with the Tim models. And an inference engine is the combination of the model and the runtime.
-

--- a/platform/using-subconscious.mdx
+++ b/platform/using-subconscious.mdx
@@ -333,6 +333,16 @@ console.log(response.choices[0].message.content);
 
 </CodeGroup>
 
+## Async workflows
+
+All of the examples above use the sync (blocking) chat completion API. When you have long‑running tasks or want stronger durability guarantees, you can switch to the async flow:
+
+- Enqueue work with `POST /v1/chat/completions/async`.
+- Poll job status with `GET /v1/requests/{requestId}/status`.
+- Optionally receive callbacks via webhooks when jobs complete.
+
+See the “Async jobs and webhooks” guide in the Platform section for a deeper walkthrough of the async pipeline and how to plug it into your own systems.
+
 ## Interpreting Results
 
 Because Subconscious uses an OpenAI-compatible API, the response structure follows the standard OpenAI format. **All of the agent's reasoning and final answer is contained within the `choices[0].message.content` field as a JSON object**. This field is not a simple string - it's always a structured JSON that provides detailed insights into the agent's reasoning process and tool usage.
@@ -423,4 +433,3 @@ This structured response format allows you to:
 - **Debug** your agent's reasoning process
 - **Monitor** tool usage and results
 - **Optimize** your tool configurations
-

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -29,7 +29,30 @@ First, create an API key from your dashboard. **Important**: API keys are only s
 
 ### Using the Subconscious API
 
-Our API is compatible with the OpenAI format in fits easily into a developer experience . Simply replace the base URL and add your API key.
+Our API is compatible with the OpenAI format and fits easily into a typical developer workflow. Simply replace the base URL and add your API key.
+
+### Async usage (high level)
+
+If you expect calls to take a while, or you want stronger durability guarantees, you can use our async API. The flow is:
+
+1. Call `POST /v1/chat/completions/async` to enqueue a job.
+2. Use `GET /v1/requests/{requestId}/status` to poll for status and results.
+
+Minimal curl example:
+
+```bash
+curl -sS https://api.subconscious.dev/v1/chat/completions/async \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "tim-large",
+    "messages": [
+      { "role": "user", "content": "Run this as an async job" }
+    ]
+  }'
+```
+
+The response includes a `requestId` you can pass to the status endpoint. For a deeper dive (including webhooks), see the “Async jobs and webhooks” guide in the Platform section.
 
 ### Python Example
 

--- a/snippets/async-polling.mdx
+++ b/snippets/async-polling.mdx
@@ -1,0 +1,74 @@
+<CodeGroup>
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.subconscious.dev/v1",
+    api_key="YOUR_API_KEY",
+)
+
+# 1) Enqueue an async job
+submit = client.chat.completions.create(
+    model="tim-large",
+    messages=[{"role": "user", "content": "Run this as an async job"}],
+    # important: use the async endpoint path
+    extra_body={"async": True},  # or call the /chat/completions/async path directly
+)
+
+request_id = submit.request_id  # or submit["requestId"] in raw JSON
+
+# 2) Poll for status
+import time, requests
+
+while True:
+    status_res = requests.get(
+        f"https://api.subconscious.dev/v1/requests/{request_id}/status",
+        headers={"Authorization": f"Bearer YOUR_API_KEY"},
+    )
+    status = status_res.json()
+    if status["status"] in ["completed", "failed"]:
+        print(status)
+        break
+    time.sleep(2)
+```
+
+```javascript JavaScript
+import OpenAI from 'openai';
+import fetch from 'node-fetch';
+
+const client = new OpenAI({
+  baseURL: 'https://api.subconscious.dev/v1',
+  apiKey: 'YOUR_API_KEY',
+});
+
+// 1) Enqueue an async job
+const submit = await client.chat.completions.create({
+  model: 'tim-large',
+  messages: [{ role: 'user', content: 'Run this as an async job' }],
+  // or use the /chat/completions/async path directly when available in your client
+});
+
+const requestId = submit.requestId;
+
+// 2) Poll for status
+async function pollStatus() {
+  while (true) {
+    const res = await fetch(
+      `https://api.subconscious.dev/v1/requests/${requestId}/status`,
+      { headers: { Authorization: `Bearer YOUR_API_KEY` } },
+    );
+    const status = await res.json();
+    if (status.status === 'completed' || status.status === 'failed') {
+      console.log(status);
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+await pollStatus();
+```
+
+</CodeGroup>
+

--- a/snippets/async-webhook.mdx
+++ b/snippets/async-webhook.mdx
@@ -1,0 +1,36 @@
+```bash
+# Enqueue an async job with a one-off callbackUrl
+curl -sS https://api.subconscious.dev/v1/chat/completions/async \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "tim-large",
+    "messages": [
+      { "role": "user", "content": "Run this as an async job and webhook me when done." }
+    ],
+    "callbackUrl": "https://your-app.example.com/webhooks/subconscious"
+  }'
+```
+
+```javascript
+// Minimal Express handler to receive webhooks
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/webhooks/subconscious', (req, res) => {
+  const { jobId, status, result, error } = req.body;
+
+  // TODO: store status, trigger follow-up actions, etc.
+  console.log('Received webhook', { jobId, status, result, error });
+
+  // Always reply 2xx quickly so we don't block retries or timeouts.
+  res.sendStatus(200);
+});
+
+app.listen(3000, () => {
+  console.log('Listening for Subconscious webhooks on :3000/webhooks/subconscious');
+});
+```
+


### PR DESCRIPTION
## Summary

This PR documents the new async jobs + webhooks pipeline and makes it discoverable from Quickstart, Platform guides, and the API Reference. The goal is that a new developer can understand when to use async, how to use it (polling + webhooks), and how to verify the system end‑to‑end.

---

## Changes

### Quickstart

- Adds an **Async usage (high level)** section:
  - Explains the enqueue + poll flow.
  - Includes a minimal `curl` example for `POST /v1/chat/completions/async`.
  - Links to the async guide for more detail.

### Platform guides

- **New page:** `platform/async-jobs-and-webhooks.mdx`
  - Explains why async exists (long‑running, durable workloads).
  - Describes the architecture: API → SQS → AsyncWorker → engines → Webhook queue → WebhookWorker → callback.
  - Defines the async job lifecycle and the polling contract:
    - `POST /v1/chat/completions/async`
    - `GET /v1/requests/{requestId}/status`
  - Describes webhooks:
    - Ephemeral `callbackUrl` per async request.
    - Persistent subscriptions for `job.succeeded` / `job.failed`.
    - Delivery semantics (timeouts, retries/backoff, DLQs).
  - Embeds code snippets:
    - `snippets/async-polling.mdx` – Python/JS enqueue + poll.
    - `snippets/async-webhook.mdx` – async with `callbackUrl` + minimal webhook handler.
  - Linked in the nav under **Guides → Platform → Async jobs and webhooks**.

- **Logs:** `platform/logs.mdx`
  - Adds an **Async jobs and webhook logs** section:
    - Worker logs and key fields (`requestId`, `jobId`, `deliveryId`, `durationMs`, `queueAgeMs`, `status`, `errorCode`).
    - Queue health + alarms (queue age, DLQ depth).
    - Local test logs from helper scripts (`*-jest.log`, `*-tsc.log`, `*-env.log`, `*-queue.json` under `apps/api/test-logs/`).

- **Models:** `platform/models.mdx`
  - Notes that TIM‑small‑preview and TIM‑large can be used with both sync and async APIs, with async routed through the background worker.

- **Using Subconscious:** `platform/using-subconscious.mdx`
  - Adds an **Async workflows** section:
    - When to prefer async over sync.
    - Mentions enqueue/poll/webhooks and links back to the async guide.

### Snippets

- `snippets/async-polling.mdx`
  - Python and JavaScript examples showing:
    - How to submit an async job.
    - How to poll `GET /v1/requests/{requestId}/status` until the job is done.

- `snippets/async-webhook.mdx`
  - `curl` example for async with `callbackUrl`.
  - Minimal Express webhook receiver implementation.

### API Reference

- `api-reference/introduction.mdx`
  - Updates intro copy to acknowledge:
    - Sync chat completions.
    - Async flow (`/v1/chat/completions/async` + `/v1/requests/{requestId}/status`).

- **New endpoint page:** `api-reference/endpoint/async.mdx`
  - “Create Async Job”:
    - Documents how to enqueue an async job.
    - Documents how to poll job status and the fields returned.
  - Linked under **API Reference → Endpoint Examples → Create Async Job**.

- **New endpoint page:** `api-reference/endpoint/webhooks.mdx`
  - “Webhooks”:
    - `POST /v1/webhooks/subscriptions` – create persistent subscriptions.
    - `GET /v1/webhooks/subscriptions` – list subscriptions.
    - `DELETE /v1/webhooks/subscriptions/{id}` – delete a subscription.
    - `POST /v1/webhooks/canary` – enqueue a synthetic delivery for verification.
    - Explains ephemeral `callbackUrl` on async jobs.
  - Linked under **API Reference → Endpoint Examples → Webhooks**.

- `docs.json`
  - Adds `platform/async-jobs-and-webhooks` to the Platform group.
  - Adds `api-reference/endpoint/async` and `api-reference/endpoint/webhooks` to Endpoint Examples.

---

## How to review

- From the docs app:
  - Guides → Platform → **Async jobs and webhooks**.
  - Guides → Get Started → **Quickstart** (see the new async section).
  - Guides → Platform → **Logs**, **Models**, **Using Subconscious**.
  - API Reference → Endpoint Examples → **Create Async Job**, **Webhooks**.

The intent is that a reader can start from Quickstart, discover async/polling/webhooks naturally, and have all the necessary details in one place without needing to read the backend code.
