### PR TITLE
Clarify TIM streaming requirement in sync examples

### DIFF
--- a/platform/using-subconscious.mdx
+++ b/platform/using-subconscious.mdx
@@ -16,6 +16,7 @@ Getting started with Subconscious is straightforward: **set your goals, make you
 3. **Call the API** - Send your request and get intelligent results
 
 ## Code Examples
+**Note:** TIM models currently require streaming (`stream=True`) for **sync** chat completions when using the OpenAI-compatible API.
 
 ### Example 1: Calling an Agent with No Tools
 
@@ -40,10 +41,13 @@ response = client.chat.completions.create(
             "role": "user",
             "content": "Find the derivative of f(x) = x^3 * sin(x)"
         }
-    ]
+    ],
+    stream=True
 )
 
-print(response.choices[0].message.content)
+# Stream and print the response
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
 ```
 
 ```javascript JavaScript
@@ -63,17 +67,21 @@ const response = await client.chat.completions.create({
       role: 'user',
       content: 'Analyze the current market trends for electric vehicles and provide a summary.'
     }
-  ]
+  ],
+  stream: true
 });
 
-console.log(response.choices[0].message.content);
+// Stream and print the response
+for await (const chunk of response) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
 ```
 
 </CodeGroup>
 
 ### Example 2: Calling an Agent with One Tool
 
-Add a single tool to extend your agent's capabilities.
+This example illustrates how tools are defined and passed to the API.
 
 <CodeGroup>
 
@@ -119,9 +127,12 @@ response = client.chat.completions.create(
         }
     ],
     tools=tools,
+    stream=True
 )
 
-print(response.choices[0].message.content)
+# Stream and print the response
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
 ```
 
 ```javascript JavaScript
@@ -166,16 +177,20 @@ const response = await client.chat.completions.create({
     }
   ],
   tools: tools,
+  stream: true
 });
 
-console.log(response.choices[0].message.content);
+// Stream and print the response
+for await (const chunk of response) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
 ```
 
 </CodeGroup>
 
 ### Example 3: Calling an Agent with Multiple Tools
 
-Combine multiple tools for more sophisticated agent behavior.
+This example shows how multiple tools can be composed for more advanced agents.
 
 <CodeGroup>
 
@@ -251,9 +266,12 @@ response = client.chat.completions.create(
         }
     ],
     tools=tools,
+    stream=True
 )
 
-print(response.choices[0].message.content)
+# Stream and print the response
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
 ```
 
 ```javascript JavaScript
@@ -326,9 +344,13 @@ const response = await client.chat.completions.create({
     }
   ],
   tools: tools,
+  stream: true
 });
 
-console.log(response.choices[0].message.content);
+// Stream and print the response
+for await (const chunk of response) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
 ```
 
 </CodeGroup>
@@ -345,11 +367,11 @@ See the “Async jobs and webhooks” guide in the Platform section for a deeper
 
 ## Interpreting Results
 
-Because Subconscious uses an OpenAI-compatible API, the response structure follows the standard OpenAI format. **All of the agent's reasoning and final answer is contained within the `choices[0].message.content` field as a JSON object**. This field is not a simple string - it's always a structured JSON that provides detailed insights into the agent's reasoning process and tool usage.
+Because Subconscious uses an OpenAI-compatible API, the response structure follows the standard OpenAI format. When collected into a complete response, the agent’s reasoning and final answer are contained within the `choices[0].message.content` field as a JSON object. This field is a string containing structured JSON that represents the agent’s reasoning process and final output.
 
 ### Response Structure
 
-The `choices[0].message.content` field contains JSON that always contains the engine's `reasoning` and `answer`. The object that follows this TypeScript interface:
+The object follows this TypeScript interface:
 
 ```typescript
 export interface ModelResponse {
@@ -392,7 +414,7 @@ Each task in the reasoning array can contain:
 
 ### Example Response
 
-The a simplified `choices[0].message.content` response will contain JSON like this:
+A simplified `choices[0].message.content` response will contain JSON like this:
 
 ```json
 {

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -56,6 +56,8 @@ The response includes a `requestId` you can pass to the status endpoint. For a d
 
 ### Python Example
 
+**Note:** TIM models currently require `stream=True` for **synchronous** chat completions when using the OpenAI-compatible API.
+
 ```python
 from openai import OpenAI
 
@@ -68,14 +70,19 @@ response = client.chat.completions.create(
     model="tim-small-preview",
     messages=[
         {"role": "user", "content": "What's the derivative of 3x^2 * sin(x)?"}
-    ]
+    ],
+    stream=True
     ## Example with no tools
 )
 
-print(response.choices[0].message.content)
+# Stream and print the response
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
 ```
 
 ### JavaScript Example
+
+**Note:** TIM models currently require `stream: true` for **synchronous** chat completions when using the OpenAI-compatible API.
 
 ```javascript
 import OpenAI from 'openai';
@@ -89,15 +96,21 @@ const response = await openai.chat.completions.create({
     model: 'tim-small-preview',
     messages: [
         { role: 'user', content: 'What's the derivative of 3x^2 * sin(x)' }
-    ]
+    ],
+    stream: true
     // Example with no tools
 
 });
 
-console.log(response.choices[0].message.content);
+// Stream and print the response
+for await (const chunk of response) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
 ```
 
 ### cURL Example
+
+**Note:** TIM models currently require `stream: true` for **synchronous** chat completions when using the OpenAI-compatible API.
 
 ```bash
 curl https://api.subconscious.dev/v1/chat/completions \
@@ -110,7 +123,8 @@ curl https://api.subconscious.dev/v1/chat/completions \
         "role": "user",
         "content": "What's the derivative of 3x^2 * sin(x)"
       }
-    ]
+    ],
+    stream: true
   }'
 ```
 


### PR DESCRIPTION
This PR makes a small documentation update to clarify that TIM models require streaming for synchronous chat completions when using the OpenAI-compatible API.

It updates the relevant code examples to use streaming and adjusts the surrounding text so it remains accurate for streamed responses.

The goal is to ensure copy-paste examples work as expected and reduce confusion for developers getting started.