### PR TITLE
docs: update MCP tools for allowedTools filtering and auth examples

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -750,9 +750,10 @@
             "type": "string",
             "description": "MCP server URI or identifier"
           },
-          "name": {
-            "type": "string",
-            "description": "Optional: specific tool name, if omitted uses all tools from server"
+          "allowedTools": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tool names to enable. Case-insensitive. Omit for all tools, [\"*\"] for explicit wildcard, [] to block all."
           },
           "auth": {
             "$ref": "#/components/schemas/McpAuth"

--- a/core-concepts/tools.mdx
+++ b/core-concepts/tools.mdx
@@ -241,6 +241,17 @@ Inject parameter values that are **hidden from the model** and automatically mer
 
 Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server and use its tools in your runs. Subconscious discovers tools from the server, filters by your `allowedTools` list, and proxies calls automatically.
 
+### Authentication
+
+MCP servers that require authentication accept an `auth` object. The auth translates to an HTTP header sent with every tool call:
+
+| Method | When to use | Header sent |
+| --- | --- | --- |
+| **Bearer** | Most common — OAuth tokens, JWTs, etc. | `Authorization: Bearer <token>` |
+| **API key** | Service-specific API keys | `<header>: <token>` (header is typically `X-Api-Key` — check your MCP server's docs) |
+
+### Schema
+
 ```typescript
 type McpTool = {
   type: "mcp";
@@ -252,9 +263,9 @@ type McpTool = {
 /**
  * MCP Authentication
  * Used for MCP tools that require authentication.
- * Will take the shape of one of the following:
- * - Bearer:  { type: "bearer", token: "<token>" }
- * - API key: { type: "api_key", token: "<token>", header: "<header>" }
+ * Translates to an HTTP header sent with every tool call:
+ * - Bearer:  { "Authorization": "Bearer <token>" }
+ * - API key: { "<header>": "<token>" }
  *
  * Bearer auth is the most common method (e.g. OAuth tokens).
  * For API key auth, the header is typically `X-Api-Key` but may vary —

--- a/core-concepts/tools.mdx
+++ b/core-concepts/tools.mdx
@@ -239,13 +239,13 @@ Inject parameter values that are **hidden from the model** and automatically mer
 
 ## MCP Tools
 
-Connect to [Model Context Protocol](https://modelcontextprotocol.io/) servers to use their tools.
+Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server and use its tools in your runs. Subconscious discovers tools from the server, filters by your `allowedTools` list, and proxies calls automatically.
 
 ```typescript
 type McpTool = {
   type: "mcp";
   server: string; // MCP server URL
-  name?: string; // Specific tool (omit to use all tools from server)
+  allowedTools?: string[]; // Tool names to enable (case-insensitive)
   auth?: {
     type: "bearer" | "api_key";
     token?: string;
@@ -254,19 +254,42 @@ type McpTool = {
 };
 ```
 
-**Example:**
+### `allowedTools` filtering
+
+| Value | Behavior |
+| --- | --- |
+| Omitted / `undefined` | All tools from the server are enabled |
+| `["*"]` | All tools enabled (explicit wildcard) |
+| `["search", "get_page"]` | Only these tools (case-insensitive match) |
+| `[]` | No tools pass through (blocks all) |
+
+### Examples
 
 ```javascript
 tools: [
   // Use all tools from an MCP server
-  { type: "mcp", server: "https://mcp.example.com" },
+  { type: "mcp", server: "https://mcp.notion.so/v1" },
 
-  // Use a specific tool with auth
+  // Filter to specific tools
+  {
+    type: "mcp",
+    server: "https://mcp.notion.so/v1",
+    allowedTools: ["search", "get_page"],
+  },
+
+  // With bearer token auth
+  {
+    type: "mcp",
+    server: "https://mcp.google.com/v1",
+    auth: { type: "bearer", token: "your-oauth-token" },
+  },
+
+  // API key auth with custom header
   {
     type: "mcp",
     server: "https://mcp.example.com",
-    name: "query_database",
-    auth: { type: "bearer", token: "your-token" },
+    allowedTools: ["query_database"],
+    auth: { type: "api_key", token: "key123", header: "X-Api-Key" },
   },
 ];
 ```

--- a/core-concepts/tools.mdx
+++ b/core-concepts/tools.mdx
@@ -244,13 +244,26 @@ Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server
 ```typescript
 type McpTool = {
   type: "mcp";
-  server: string; // MCP server URL
+  url: string; // MCP server URL
   allowedTools?: string[]; // Tool names to enable (case-insensitive)
-  auth?: {
-    type: "bearer" | "api_key";
-    token?: string;
-    header?: string; // Header name for api_key auth
-  };
+  auth?: McpAuth;
+};
+
+/**
+ * MCP Authentication
+ * Used for MCP tools that require authentication.
+ * Will take the shape of one of the following:
+ * - Bearer:  { type: "bearer", token: "<token>" }
+ * - API key: { type: "api_key", token: "<token>", header: "<header>" }
+ *
+ * Bearer auth is the most common method (e.g. OAuth tokens).
+ * For API key auth, the header is typically `X-Api-Key` but may vary —
+ * check the documentation of the MCP server you are connecting to.
+ */
+type McpAuth = {
+  type: "bearer" | "api_key";
+  token: string;
+  header?: string; // For api_key auth, the header name (e.g. "X-Api-Key")
 };
 ```
 
@@ -268,26 +281,28 @@ type McpTool = {
 ```javascript
 tools: [
   // Use all tools from an MCP server
-  { type: "mcp", server: "https://mcp.notion.so/v1" },
+  { type: "mcp", url: "https://mcp.notion.so/v1" },
 
   // Filter to specific tools
   {
     type: "mcp",
-    server: "https://mcp.notion.so/v1",
+    url: "https://mcp.notion.so/v1",
     allowedTools: ["search", "get_page"],
   },
 
-  // With bearer token auth
+  // With bearer token auth (most common — e.g. OAuth tokens)
   {
     type: "mcp",
-    server: "https://mcp.google.com/v1",
+    url: "https://mcp.google.com/v1",
     auth: { type: "bearer", token: "your-oauth-token" },
   },
 
   // API key auth with custom header
+  // The header is typically "X-Api-Key" but may vary —
+  // check the docs of the MCP server you are connecting to.
   {
     type: "mcp",
-    server: "https://mcp.example.com",
+    url: "https://mcp.example.com",
     allowedTools: ["query_database"],
     auth: { type: "api_key", token: "key123", header: "X-Api-Key" },
   },


### PR DESCRIPTION
Replace name (single tool) with allowedTools (array-based filtering). Add filtering behavior table, richer examples with bearer/api_key auth. Update OpenAPI schema to match.