### PR TITLE
update base url to api-legacy.subconscious.dev

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -45,7 +45,7 @@ Request structured responses using JSON Schema via the `answerFormat` field.
 All API endpoints require Bearer token authentication:
 
 ```bash
-curl https://api.subconscious.dev/v1/runs \
+curl https://api-legacy.subconscious.dev/v1/runs \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"engine": "tim", "input": {"instructions": "..."}}'
@@ -58,7 +58,7 @@ Get your API key from the [Subconscious platform](https://www.subconscious.dev/p
 ### Create an async run
 
 ```bash
-curl -X POST https://api.subconscious.dev/v1/runs \
+curl -X POST https://api-legacy.subconscious.dev/v1/runs \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -81,7 +81,7 @@ Response:
 ### Poll for results
 
 ```bash
-curl https://api.subconscious.dev/v1/runs/run_abc123 \
+curl https://api-legacy.subconscious.dev/v1/runs/run_abc123 \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
@@ -108,7 +108,7 @@ Response (when complete):
 Instead of polling, configure webhooks to receive notifications when runs complete:
 
 ```bash
-curl -X POST https://api.subconscious.dev/v1/webhooks/subscriptions \
+curl -X POST https://api-legacy.subconscious.dev/v1/webhooks/subscriptions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -10,7 +10,7 @@
   },
   "servers": [
     {
-      "url": "https://api.subconscious.dev/v1"
+      "url": "https://api-legacy.subconscious.dev/v1"
     }
   ],
   "security": [

--- a/core-concepts/async-webhooks.mdx
+++ b/core-concepts/async-webhooks.mdx
@@ -27,7 +27,7 @@ Subscribe to events across all runs in your org. You can manage subscriptions th
 ### Create a Subscription
 
 ```bash
-curl -X POST https://api.subconscious.dev/v1/webhooks/subscriptions \
+curl -X POST https://api-legacy.subconscious.dev/v1/webhooks/subscriptions \
   -H "Authorization: Bearer $SUBCONSCIOUS_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -88,7 +88,7 @@ def verify_webhook(payload_bytes: bytes, secret: str, signature: str) -> bool:
 For one-off deliveries, pass `callbackUrl` on the run request:
 
 ```bash
-curl -X POST https://api.subconscious.dev/v1/runs \
+curl -X POST https://api-legacy.subconscious.dev/v1/runs \
   -H "Authorization: Bearer $SUBCONSCIOUS_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/core-concepts/skills.mdx
+++ b/core-concepts/skills.mdx
@@ -43,7 +43,7 @@ const run = await client.run({
 ```
 
 ```bash cURL
-curl https://api.subconscious.dev/v1/runs \
+curl https://api-legacy.subconscious.dev/v1/runs \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{

--- a/core-concepts/streaming.mdx
+++ b/core-concepts/streaming.mdx
@@ -55,7 +55,7 @@ for event in client.stream(
 ```
 
 ```bash cURL
-curl https://api.subconscious.dev/v1/runs/stream \
+curl https://api-legacy.subconscious.dev/v1/runs/stream \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -N \

--- a/machine-payments.mdx
+++ b/machine-payments.mdx
@@ -149,16 +149,16 @@ Free, no payment required. Poll until `status` is `succeeded` or `failed`.
 
 ```bash
 # 1. Hit the endpoint (returns 402 with payment details)
-curl -X POST https://api.subconscious.dev/v1/machines/searches \
+curl -X POST https://api-legacy.subconscious.dev/v1/machines/searches \
   -H "Content-Type: application/json" \
   -d '{"instructions": "Latest AI news"}'
 
 # 2. Pay with purl (x402 CLI), which handles payment and returns runId
-purl -X POST https://api.subconscious.dev/v1/machines/searches \
+purl -X POST https://api-legacy.subconscious.dev/v1/machines/searches \
   -d '{"instructions": "Latest AI news"}'
 
 # 3. Poll for result (free, no payment needed)
-curl https://api.subconscious.dev/v1/machines/searches/<runId>
+curl https://api-legacy.subconscious.dev/v1/machines/searches/<runId>
 ```
 
 ---

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -108,7 +108,7 @@ print(run.result.answer)
 ```
 
 ```bash cURL
-curl https://api.subconscious.dev/v1/runs \
+curl https://api-legacy.subconscious.dev/v1/runs \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{

--- a/snippets/async-webhook.mdx
+++ b/snippets/async-webhook.mdx
@@ -2,7 +2,7 @@
 
 ```bash cURL
 # Start a run with a callback URL (output.callbackUrl)
-curl -X POST https://api.subconscious.dev/v1/runs \
+curl -X POST https://api-legacy.subconscious.dev/v1/runs \
   -H "Authorization: Bearer $SUBCONSCIOUS_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/quickstart.mdx
+++ b/snippets/quickstart.mdx
@@ -41,7 +41,7 @@ console.log(run.result?.answer);
 ```
 
 ```bash cURL
-curl -X POST https://api.subconscious.dev/v1/runs \
+curl -X POST https://api-legacy.subconscious.dev/v1/runs \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d "{


### PR DESCRIPTION
## Summary
- Updates all `api.subconscious.dev` references in docs to `api-legacy.subconscious.dev`
- Covers curl snippets across quickstart, machine-payments, streaming, skills, async-webhooks, api-reference/introduction, and the OpenAPI server URL

## Test plan
- [ ] Run the curl examples against the legacy host
- [ ] Verify the rendered Mintlify pages show the new URL in code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)